### PR TITLE
Configure ci-jobs

### DIFF
--- a/jjb/ci-management/ci-jobs.yaml
+++ b/jjb/ci-management/ci-jobs.yaml
@@ -1,0 +1,16 @@
+---
+- ci_jobs_common: &ci_jobs_common
+    name: ci-jobs-common
+    # Defines common ci-jobs configuration
+
+    project: ci-management
+    project-name: ci-management
+    build-node: centos7-builder-1c-1g
+
+- project:
+    name: github-ci-jobs
+
+    jobs:
+      - '{project-name}-github-ci-jobs'
+
+    <<: *ci_jobs_common

--- a/jjb/defaults.yaml
+++ b/jjb/defaults.yaml
@@ -1,0 +1,22 @@
+---
+
+### Global JJB defaults
+
+- defaults:
+    name: global
+
+    # lf-infra-defaults
+    jenkins-ssh-credential: jenkins-ssh
+    lftools-version: <1.0.0
+
+    # GitHub configuration
+    git-url: https://github.com
+    git-clone-url: 'git@github.com:'
+    github-org: jquery
+    submodule-recursive: true
+
+    # build defaults
+    build-days-to-keep: 30
+    # Timeout in minutes
+    build-timeout: 360
+    build-node: centos7-builder-1c-1g


### PR DESCRIPTION
Configuring global-jjb defaults and ci-management verify job.

Signed-off-by: Vanessa Rene Valderrama <vvalderrama@linuxfoundation.org>