### PR TITLE
Configure ci-jobs

### DIFF
--- a/jjb/ci-management/ci-jobs.yaml
+++ b/jjb/ci-management/ci-jobs.yaml
@@ -14,3 +14,18 @@
       - '{project-name}-github-ci-jobs'
 
     <<: *ci_jobs_common
+
+    views:
+      - project-view
+
+- project:
+    name: openstack-cron
+
+    jobs:
+      - github-openstack-cron
+
+    <<: *ci_jobs_common
+
+    jenkins-urls: >
+        https://jenkins.openjsf.org
+    openstack-cloud: vex

--- a/jjb/defaults.yaml
+++ b/jjb/defaults.yaml
@@ -15,6 +15,15 @@
     github-org: jquery
     submodule-recursive: true
 
+    # default pr_whitelist to some LF RelEng staff
+    github_pr_whitelist:
+      - tykeal
+      - MightyNerdEric
+      - vvalderrv
+    # default pr_admin_list to LF RelEng lead
+    github_pr_admin_list:
+      - tykeal
+
     # build defaults
     build-days-to-keep: 30
     # Timeout in minutes


### PR DESCRIPTION
Configuring defaults, project view and opestack cron

Signed-off-by: Vanessa Rene Valderrama <vvalderrama@linuxfoundation.org>