### PR TITLE
Fix ci-management jobs default branch

### DIFF
--- a/jjb/ci-management/ci-jobs.yaml
+++ b/jjb/ci-management/ci-jobs.yaml
@@ -4,6 +4,7 @@
     # Defines common ci-jobs configuration
 
     project: ci-management
+    branch: main
     project-name: ci-management
     build-node: centos7-builder-1c-1g
 

--- a/jjb/ci-management/ci-packer.yaml
+++ b/jjb/ci-management/ci-packer.yaml
@@ -4,6 +4,7 @@
     # Defines common ci-packer configuration
 
     project: ci-management
+    branch: main
     project-name: ci-management
     build-node: centos7-builder-1c-1g
 


### PR DESCRIPTION
Changing the ci-management jobs default from master to main

Signed-off-by: Vanessa Rene Valderrama <vvalderrama@linuxfoundation.org>