### PR TITLE
Remove sandbox from silos

### DIFF
--- a/jjb/ci-management/ci-jobs.yaml
+++ b/jjb/ci-management/ci-jobs.yaml
@@ -13,6 +13,8 @@
 
     jobs:
       - '{project-name}-github-ci-jobs'
+      - gerrit-jenkins-cfg-merge:
+          jenkins-silos: production
 
     <<: *ci_jobs_common
 


### PR DESCRIPTION
Removing sandbox from jenkins-silos until we add a sandbox instance

Signed-off-by: Vanessa Rene Valderrama <vvalderrama@linuxfoundation.org>