### PR TITLE
Fix the Jenkins config job

### DIFF
--- a/jjb/ci-management/ci-jobs.yaml
+++ b/jjb/ci-management/ci-jobs.yaml
@@ -13,7 +13,7 @@
 
     jobs:
       - '{project-name}-github-ci-jobs'
-      - gerrit-jenkins-cfg-merge:
+      - github-jenkins-cfg-merge:
           jenkins-silos: production
 
     <<: *ci_jobs_common


### PR DESCRIPTION
Modifying the Jenkins config job to use the GitHub template

Signed-off-by: Vanessa Rene Valderrama <vvalderrama@linuxfoundation.org>