### PR TITLE
Add Nexus variable

### DIFF
--- a/jenkins-config/global-vars-production.sh
+++ b/jenkins-config/global-vars-production.sh
@@ -6,3 +6,4 @@ LOGS_SERVER=https://logs.openjsf.org
 SILO=production
 S3_BUCKET=ojsf-logs-s3-cloudfront-index
 CDN_URL=logs.openjsf.org
+NEXUS_URL=


### PR DESCRIPTION
Adding an empty Nexus variable, JQuery doesn't have an Nexus instance
but it's a required global env var.

Signed-off-by: Vanessa Rene Valderrama <vvalderrama@linuxfoundation.org>