### PR TITLE
Fix ci-jobs

### DIFF
--- a/jjb/ci-management/ci-jobs.yaml
+++ b/jjb/ci-management/ci-jobs.yaml
@@ -14,8 +14,7 @@
     name: github-ci-jobs
 
     jobs:
-      - '{project-name}-github-ci-jobs'
-      - github-jenkins-cfg-merge:
+      - '{project-name}-github-ci-jobs':
           jenkins-silos: production
 
     <<: *ci_jobs_common


### PR DESCRIPTION
Remove common-ci-jobs and only use github-ci-jobs

Signed-off-by: Vanessa Rene Valderrama <vvalderrama@linuxfoundation.org>