### PR TITLE
Remove LOGS_SERVER variable

### DIFF
--- a/jenkins-config/global-vars-production.sh
+++ b/jenkins-config/global-vars-production.sh
@@ -2,7 +2,6 @@ GIT_BASE=https://github.com/jquery/$PROJECT
 GIT_CLONE_URL=git@github.com:
 GIT_URL=https://github.com
 JENKINS_HOSTNAME=vex-yul-ojsf-jenkins-prod-1
-LOGS_SERVER=https://logs.openjsf.org
 SILO=production
 S3_BUCKET=ojsf-logs-s3-cloudfront-index
 CDN_URL=logs.openjsf.org


### PR DESCRIPTION
The logs-deploy script uses LOGS_SERVER and S3_BUCKET to determine where
to deploy logs. Removing the LOGS_SERVER variable so the logs deploy to
S3

Signed-off-by: Vanessa Rene Valderrama <vvalderrama@linuxfoundation.org>