### PR TITLE
Update ci-jobs

### DIFF
--- a/jjb/ci-management/ci-jobs.yaml
+++ b/jjb/ci-management/ci-jobs.yaml
@@ -8,7 +8,7 @@
     stream: main
     sha1: origin/main
     project-name: ci-management
-    build-node: centos7-builder-1c-1g
+    build-node: centos7-builder-2c-2g
     jjb-version: 3.5.0
     jenkins-silos: production
 


### PR DESCRIPTION
Removing jenkins-cfg jobs, they're no longer needed because cloud
configs are managed via JCasC.

Modifying the builder to use the new V3 builders.

Signed-off-by: Vanessa Rene Valderrama <vvalderrama@linuxfoundation.org>