### PR TITLE
Fix: JQuery Core Build Node

### DIFF
--- a/jjb/defaults.yaml
+++ b/jjb/defaults.yaml
@@ -28,7 +28,7 @@
     build-days-to-keep: 7
     # Timeout in minutes
     build-timeout: 360
-    build-node: centos7-builder-1c-1g
+    build-node: centos7-builder-2c-2g
 
     # openstack-cron email notification defaults
     failure-notification: "releng+openjsf@linuxfoundation.org"


### PR DESCRIPTION
Modifying the node to use the current 2c-2g executor

Signed-off-by: Vanessa Rene Valderrama <vvalderrama@linuxfoundation.org>