### PR TITLE
Fix: Correct region_name definition in cloud yaml

### DIFF
--- a/jenkins-config/managed-config-files/custom/clouds-yaml/content
+++ b/jenkins-config/managed-config-files/custom/clouds-yaml/content
@@ -7,4 +7,4 @@ clouds:
       auth_url: 'https://auth.vexxhost.net/v3'
       user_domain_name: Default
       project_domain_name: Default
-      region_name: ca-ymq-1
+    region_name: ca-ymq-1


### PR DESCRIPTION
The region_name variable is not valid inside the auth block. This is
causing issues with the regular cron job.

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>