### PR TITLE
Chore: Upgrade JJB version

### DIFF
--- a/jjb/ci-management/ci-jobs.yaml
+++ b/jjb/ci-management/ci-jobs.yaml
@@ -9,7 +9,7 @@
     sha1: origin/main
     project-name: ci-management
     build-node: centos7-builder-2c-2g
-    jjb-version: 3.5.0
+    jjb-version: 4.1.0
     jenkins-silos: production
 
 - project:


### PR DESCRIPTION
Upgrading the JJB version to use the version required
by Global-JJB to resolve plugin installation issues

Signed-off-by: Vanessa Valderrama <vvalderrama@linuxfoundation.org>